### PR TITLE
ci: complete npm OIDC trusted publishing migration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,15 +4,19 @@ on:
   push:
     branches:
       - main
+  # Manual recovery: publish the current main (package.json version) via OIDC
+  # without cutting a new release. Used to ship a tagged release whose npm
+  # publish previously failed.
+  workflow_dispatch: {}
 
 permissions:
   contents: write
   pull-requests: write
   issues: write
-  packages: write
 
 jobs:
   release-please:
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -25,18 +29,24 @@ jobs:
 
   publish-npm:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
+    # Run after release-please creates a release, or on a manual dispatch.
+    if: ${{ always() && (needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # OIDC token for npm trusted publishing
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install bun
         run: npm install -g bun
       - name: Install dependencies
         run: bun install
-      - name: Publish to NPM
+      - name: Ensure npm supports trusted publishing
+        run: npm install -g npm@latest
+      - name: Publish to NPM (OIDC trusted publishing)
         run: npm publish


### PR DESCRIPTION
## Why

`socketrpc-gen` on the public npm registry is stuck at **4.0.1**. The `chore(main): release 6.0.0` run failed at `npm publish`:

```
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
```

The workflow had no usable auth — the `NPM_TOKEN` secret is absent/empty and OIDC was not wired up. A trusted publisher (`nguyenvanduocit/socketrpc-gen` → `publish.yml`) is already registered on npmjs.com.

## Changes

- `id-token: write` on `publish-npm` (OIDC trusted publishing) — no `NPM_TOKEN`
- upgrade npm to `latest` on the runner (trusted publishing needs ≥ 11.5.1)
- `workflow_dispatch` recovery job to publish current `main` (v6.0.0) via OIDC
- remove unused `packages: write` (ex-GitHub-Packages residue)

## Ship 6.0.0

After merge, trigger **Release and Publish** via `workflow_dispatch` to publish the tagged `v6.0.0` (package.json already at 6.0.0) through OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)