### PR TITLE
ci: engage OIDC by removing setup-node registry-url

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,10 +37,13 @@ jobs:
       id-token: write # OIDC token for npm trusted publishing
     steps:
       - uses: actions/checkout@v4
+      # No registry-url: setup-node's registry-url writes an .npmrc with a
+      # placeholder _authToken, which makes npm use token auth and skip the
+      # OIDC exchange. Without it, npm has no token configured and performs
+      # trusted publishing against the default registry (registry.npmjs.org).
       - uses: actions/setup-node@v4
         with:
           node-version: '22.x'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install bun
         run: npm install -g bun


### PR DESCRIPTION
Follow-up to #28. The dispatch publish got past auth but failed with a 404: setup-node's registry-url wrote an .npmrc with a placeholder NODE_AUTH_TOKEN, so npm used bogus token auth instead of OIDC. Fix: remove registry-url so npm performs OIDC trusted publishing against the default registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)