### PR TITLE
ci: use Node 24 so npm supports OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,19 +37,17 @@ jobs:
       id-token: write # OIDC token for npm trusted publishing
     steps:
       - uses: actions/checkout@v4
-      # No registry-url: setup-node's registry-url writes an .npmrc with a
-      # placeholder _authToken, which makes npm use token auth and skip the
-      # OIDC exchange. Without it, npm has no token configured and performs
-      # trusted publishing against the default registry (registry.npmjs.org).
+      # Node 24 bundles npm >= 11.5.1, the minimum that performs npm OIDC
+      # trusted publishing. npm 11.5.1+ prefers OIDC over setup-node's
+      # placeholder token, so registry-url is kept per the npm docs recipe.
       - uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install bun
         run: npm install -g bun
       - name: Install dependencies
         run: bun install
-      - name: Ensure npm supports trusted publishing
-        run: npm install -g npm@latest
       - name: Publish to NPM (OIDC trusted publishing)
         run: npm publish


### PR DESCRIPTION
Follow-up to #28/#29. Trusted publishing needs npm >= 11.5.1, but node-version '22.x' bundles npm 10.9.x (no OIDC) and the manual npm@latest upgrade didn't take effect — causing the 404 (placeholder token) then ENEEDAUTH (no OIDC). Per the npm docs recipe, use Node 24 (bundles npm >= 11.5.1) with registry-url and no token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)