### PR TITLE
ci: verbose npm publish to trace OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install dependencies
         run: bun install
       - name: Publish to NPM (OIDC trusted publishing)
-        run: npm publish
+        run: npm publish --loglevel=verbose
         env:
           # setup-node injects a placeholder NODE_AUTH_TOKEN when registry-url
           # is set; it takes precedence over OIDC and fails with a 404. Clearing


### PR DESCRIPTION
temporary verbose logging