### PR TITLE
ci: drop temporary verbose publish logging

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install dependencies
         run: bun install
       - name: Publish to NPM (OIDC trusted publishing)
-        run: npm publish --loglevel=verbose
+        run: npm publish
         env:
           # setup-node injects a placeholder NODE_AUTH_TOKEN when registry-url
           # is set; it takes precedence over OIDC and fails with a 404. Clearing


### PR DESCRIPTION
6.0.0 is now published via OIDC trusted publishing. Remove the temporary --loglevel=verbose debugging flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)